### PR TITLE
Ensure background images are not fetched for small screens

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -867,6 +867,7 @@ nav ul li {
 }
 @media screen and (max-width: 767px) {
   .section-parallax-img {
+    background-image: none !important;
     display: none;
   }
 }

--- a/less/main.less
+++ b/less/main.less
@@ -87,7 +87,9 @@
   position: relative;
   padding: 0;
   height: 600px;
+  
   @media @small {
+    background-image: none !important;
     display: none;
   }
 }


### PR DESCRIPTION
- Set the background-image to none to prevent browser from loading the image.
