### PR TITLE
adding a top offset to scrollit

### DIFF
--- a/index.html
+++ b/index.html
@@ -197,7 +197,7 @@
                 }
             });
 
-            $(function(){$.scrollIt({scrollTime: 1000});});
+            $(function(){$.scrollIt({scrollTime: 1000, topOffset: -82});});
         </script>
 
         <script type="text/javascript">


### PR DESCRIPTION
Fixes issue #20

Now that the mobile menu is gone, we don't actually need to remove the padding. This simple change to have scrollit have a 82px top offset achieves the goal nicely.
