### PR TITLE
The embedded Google Maps doesn't scale properly on mobile

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -1029,3 +1029,14 @@ td {
 .sponsorship-item-desc {
   color: #555555;
 }
+#venue .map {
+  position: relative;
+  height: 450px;
+  overflow: hidden;
+}
+#venue .map iframe {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+}

--- a/index.html
+++ b/index.html
@@ -110,7 +110,7 @@
                     <p><a href="http://www.marriott.com/hotels/travel/mcidt-kansas-city-marriott-downtown/">Kansas City Marriott Downtown</a></p>
                     <p>200 W 12th St, Kansas City, MO 64105</p>
                   </div>
-                  <div class="span6">
+                  <div class="map">
                     <iframe width="600" height="450" frameborder="0" style="border:0" src="https://www.google.com/maps/embed/v1/place?q=Kansas%20City%20Marriott%20Downtown%2C%20West%2012th%20Street%2C%20Kansas%20City%2C%20MO%2C%20United%20States&key=AIzaSyB1ka1HSezM6HW02Zo1J_oGCp7HhPKal0I"></iframe>
                   </div>
                 </div>

--- a/less/main.less
+++ b/less/main.less
@@ -236,3 +236,15 @@ th, td {
 .sponsorship-item-desc {
   color: @gray;
 }
+
+#venue .map {
+  position: relative;
+  height: 450px;
+  overflow: hidden;
+  iframe {
+    position: absolute;
+    width: 100%;
+    top: 0;
+    left: 0;
+  }
+}


### PR DESCRIPTION
Using absolute positioning on the iframe inside of relative position on the div surrounding allows the iframe to take up 100% of the width of the size of the div, which works on mobile much better.
