### PR TITLE
add just a little bit of padding to schedule slot on small form factor

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -1113,8 +1113,7 @@ td {
 }
 @media screen and (max-width: 767px) {
   .section-schedule .schedule-slot {
-    padding-left: 5px;
-    padding-right: 5px;
+    padding: 5px 15px;
   }
 }
 .section-schedule .schedule-slot-muted {

--- a/less/main.less
+++ b/less/main.less
@@ -320,8 +320,7 @@ th, td {
     border: 1px solid #ddd;
 
     @media @small {
-      padding-left: 5px;
-      padding-right: 5px;
+      padding: 5px 15px;
     }
   }
 


### PR DESCRIPTION
Each of the schedule-slot could use a little bit of padding on the left and right so the speaker photo isn't right up to the border.

Before:
![before](https://cloud.githubusercontent.com/assets/253647/2956923/ec117bf2-da97-11e3-84dc-40780e6498cb.png)

After:
![after](https://cloud.githubusercontent.com/assets/253647/2956924/ee1963a6-da97-11e3-8f14-ab5bb92bb267.png)
